### PR TITLE
Updates SBCL, qlot, and server-starter

### DIFF
--- a/minimum/docker/Dockerfile-app
+++ b/minimum/docker/Dockerfile-app
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:experimental
-ARG SBCL_VERSION=2.0.9
+ARG SBCL_VERSION=2.5.1
 FROM fukamachi/sbcl:${SBCL_VERSION}
-ARG QLOT_VERSION=0.10.7
+ARG QLOT_VERSION=1.6.0
 ENV PATH /root/go/bin:${PATH}
 
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt set -x; \
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
     gcc \
     libc6-dev && \
   ros install fukamachi/qlot/${QLOT_VERSION} && \
-  go get github.com/lestrrat-go/server-starter/cmd/start_server
+  go install github.com/lestrrat-go/server-starter/cmd/start_server@0.0.2
 
 WORKDIR /app
 RUN ros -e '(ql:quickload :qlot/distify)'

--- a/minimum/qlfile.lock
+++ b/minimum/qlfile.lock
@@ -1,16 +1,16 @@
 ("quicklisp" .
  (:class qlot/source/dist:source-dist
-  :initargs (:distribution "http://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
-  :version "2020-12-20"))
+  :initargs (:distribution "https://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
+  :version "2024-10-12"))
 ("utopian" .
  (:class qlot/source/git:source-git
   :initargs (:remote-url "https://github.com/fukamachi/utopian")
-  :version "git-cc89a20368b5b42befb35761442b4b29b5f5a6fc"))
+  :version "git-8c0ec6b1c4d43eb60c58f38f67f51bc637968a35"))
 ("clack" .
  (:class qlot/source/ql:source-ql
   :initargs (:%version :latest)
-  :version "ql-2020-12-20"))
+  :version "ql-2024-10-12"))
 ("lsx" .
  (:class qlot/source/github:source-github
   :initargs (:repos "fukamachi/lsx" :ref nil :branch nil :tag nil)
-  :version "github-546032449c010e4153501accf1cac521"))
+  :version "github-3a8ecea78080a0c7afe9bd8a0c594efd1b227de9"))

--- a/standard/docker/Dockerfile-app
+++ b/standard/docker/Dockerfile-app
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:experimental
-ARG SBCL_VERSION=2.0.9
+ARG SBCL_VERSION=2.5.1
 FROM fukamachi/sbcl:${SBCL_VERSION}
-ARG QLOT_VERSION=0.10.7
+ARG QLOT_VERSION=1.6.0
 ENV APP_ENV local
 ENV PATH /root/go/bin:${PATH}
 
@@ -13,7 +13,7 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
     gcc \
     libc6-dev && \
   ros install fukamachi/qlot/${QLOT_VERSION} && \
-  go get github.com/lestrrat-go/server-starter/cmd/start_server
+  go install github.com/lestrrat-go/server-starter/cmd/start_server@0.0.2
 
 WORKDIR /app
 RUN ros -e '(ql:quickload :qlot/distify)'

--- a/standard/qlfile.lock
+++ b/standard/qlfile.lock
@@ -1,12 +1,12 @@
 ("quicklisp" .
  (:class qlot/source/dist:source-dist
-  :initargs (:distribution "http://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
-  :version "2020-12-20"))
+  :initargs (:distribution "https://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
+  :version "2024-10-12"))
 ("utopian" .
  (:class qlot/source/git:source-git
   :initargs (:remote-url "https://github.com/fukamachi/utopian")
-  :version "git-532431b4c5e958995ba2d812751b779f814f9810"))
+  :version "git-8c0ec6b1c4d43eb60c58f38f67f51bc637968a35"))
 ("clack" .
  (:class qlot/source/ql:source-ql
   :initargs (:%version :latest)
-  :version "ql-2020-12-20"))
+  :version "ql-2024-10-12"))


### PR DESCRIPTION
Go changed how you download modules. Go mod no longer works, need to use go install + a version number.

Updated SBCL to 2.5.1

Update qlot to 1.6.0

Updated qlot.lock as the version `lsx` was pinned to 404d when trying to install